### PR TITLE
Enable camera access for face liveness WebView

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -638,7 +638,7 @@ packages:
     source: hosted
     version: "4.13.0"
   webview_flutter_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: webview_flutter_android
       sha256: "9a25f6b4313978ba1c2cda03a242eea17848174912cfb4d2d8ee84a556f248e3"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   # WebView and permissions for Face Liveness integration
   permission_handler: ^11.3.1
   webview_flutter: ^4.4.2  # For React Face Liveness WebView integration
+  webview_flutter_android: ^4.7.0  # Android-specific WebView features
   shared_preferences: ^2.2.2  # For JWT token persistence
   url_launcher: ^6.3.1  # For opening URLs in web testing
   provider: ^6.1.2  # State management


### PR DESCRIPTION
## Summary
- automatically grant WebView camera/microphone requests via AndroidWebViewController
- remove unsupported onPermissionRequest callback
- depend on webview_flutter_android for Android-specific features

## Testing
- `dart format lib/widgets/webview_face_liveness.dart` *(fails: command not found: dart)*
- `flutter analyze` *(fails: command not found: flutter)*
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68b364a64cf0832d908fd3d2124e1399