### PR TITLE
feat: ensure mounted before setState in auth wrapper

### DIFF
--- a/lib/widgets/auth_wrapper.dart
+++ b/lib/widgets/auth_wrapper.dart
@@ -78,11 +78,14 @@ class _AuthWrapperState extends State<AuthWrapper> {
   Future<void> _checkAuthStatus() async {
     try {
       final isAuthenticated = await AuthService.isAuthenticated();
+      if (!mounted) return;
       final isOnboardingComplete = await AuthService.isOnboardingComplete();
+      if (!mounted) return;
 
       if (isAuthenticated) {
         // Verify token is still valid and get user data
         final userResult = await AuthService.getCurrentUser();
+        if (!mounted) return;
         final tokenValid =
             userResult['success'] && !userResult.containsKey('requiresAuth');
 
@@ -95,7 +98,8 @@ class _AuthWrapperState extends State<AuthWrapper> {
           
           // If user status is 'verified', they should go to main app regardless of onboarding flag
           final shouldShowMainApp = userStatus == 'verified' || isOnboardingComplete;
-          
+
+          if (!mounted) return;
           setState(() {
             _isAuthenticated = true;
             _isOnboardingComplete = shouldShowMainApp;
@@ -106,9 +110,11 @@ class _AuthWrapperState extends State<AuthWrapper> {
           if (userStatus == 'verified' && !isOnboardingComplete) {
             print('✅ User is verified, marking onboarding as complete');
             await AuthService.completeOnboarding();
+            if (!mounted) return;
           }
         } else {
           // Token invalid
+          if (!mounted) return;
           setState(() {
             _isAuthenticated = false;
             _isOnboardingComplete = false;
@@ -116,6 +122,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
           });
         }
       } else {
+        if (!mounted) return;
         setState(() {
           _isAuthenticated = false;
           _isOnboardingComplete = false;
@@ -124,6 +131,7 @@ class _AuthWrapperState extends State<AuthWrapper> {
       }
     } catch (e) {
       print('❌ Error checking auth status: $e');
+      if (!mounted) return;
       setState(() {
         _isAuthenticated = false;
         _isOnboardingComplete = false;


### PR DESCRIPTION
## Summary
- ensure state updates in auth wrapper only occur when widget is mounted

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b365b7ca7c832db6e0d5725575310b