### PR TITLE
Allow non-string liveness messages

### DIFF
--- a/lib/features/face-scan/screens/facescan-home.dart
+++ b/lib/features/face-scan/screens/facescan-home.dart
@@ -135,10 +135,11 @@ class _FaceScanSetupState extends State<FaceScanSetup> {
       // Show "Under Verification" modal and start polling
       _showVerificationBottomSheet(sessionId);
     } else {
+      final message = result.message;
       _showErrorDialog(
-        result.message.isNotEmpty
-            ? result.message
-            : 'Face scan failed. Please try again.',
+        message is String && message.isNotEmpty
+            ? message
+            : (message?.toString() ?? 'Face scan failed. Please try again.'),
       );
     }
   }

--- a/lib/widgets/webview_face_liveness.dart
+++ b/lib/widgets/webview_face_liveness.dart
@@ -10,7 +10,7 @@ class FaceLivenessResult {
   final bool success;
   final bool isLive;
   final double confidence;
-  final String message;
+  final Object? message;
   final String? sessionId;
   final Map<String, dynamic>? fullResult;
 
@@ -24,11 +24,17 @@ class FaceLivenessResult {
   });
 
   factory FaceLivenessResult.fromJson(Map<String, dynamic> json) {
+    var message = json['message'];
+    // Fallback to string representation for backward compatibility
+    if (message != null && message is! String) {
+      message = message.toString();
+    }
+
     return FaceLivenessResult(
       success: json['success'] ?? false,
       isLive: json['isLive'] ?? false,
       confidence: (json['confidence'] ?? 0.0).toDouble(),
-      message: json['message'] ?? 'Unknown result',
+      message: message ?? 'Unknown result',
       sessionId: json['sessionId'],
       fullResult: json['fullResult'],
     );
@@ -322,7 +328,7 @@ class _WebViewFaceLivenessState extends State<WebViewFaceLiveness> {
       } else if (data['type'] == 'FACE_LIVENESS_ERROR') {
         print('❌ Processing Face Liveness error: ${data['message']}');
         if (widget.onError != null) {
-          widget.onError!(data['message'] ?? 'Unknown error');
+          widget.onError!(data['message']?.toString() ?? 'Unknown error');
         }
       } else if (data['type'] == 'FACE_LIVENESS_CANCEL') {
         print('🚫 Processing Face Liveness cancel');


### PR DESCRIPTION
## Summary
- allow `FaceLivenessResult.message` to store non-string data
- normalize liveness error messages to strings
- safely display liveness messages that may be non-strings

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b365b60468832d8d0fd0385a0fc5da